### PR TITLE
Module "install" does not exist

### DIFF
--- a/kw_manifests.module
+++ b/kw_manifests.module
@@ -153,7 +153,7 @@ function kw_manifests_run($info) {
     return FALSE;
   }
 
-  module_load_include($info['module'], 'install');
+  module_load_include('install', $info['module']);
 
   if (isset($info['file'])) {
     $path = isset($info['file path']) ? $info['file path'] : drupal_get_path('module', $info['module']);


### PR DESCRIPTION
The KW Manifests module tries to load the module "install" with a module_load_include, this module does not exists, this is especially a problem since Drupal 7.33. 
See: https://www.drupal.org/node/1081266

See here for the cause: https://github.com/kraftwagen/kw-manifests/blob/master/kw_manifests.module#L156

I think the function call is wrong and should be the other way around.
